### PR TITLE
Fix plugin might break the Matomo installer if shipped together

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -6,6 +6,11 @@ return array(
     'Piwik\View\SecurityPolicy' => DI\decorate(function ($previous) {
         /** @var \Piwik\View\SecurityPolicy $previous */
 
+        if (!\Piwik\SettingsPiwik::isMatomoInstalled()) {
+            // if Matomo is not yet installed there can't be any system setting
+            return $previous;
+        }
+
         $settings = new Piwik\Plugins\AnonymousPiwikUsageMeasurement\SystemSettings();
         $customSiteUrl = $settings->getSetting('customSiteUrl')->getValue();
         $host = parse_url($customSiteUrl, PHP_URL_HOST);


### PR DESCRIPTION
### Description:

The config tries to check a system setting. If Matomo is not yet installed, but the plugin is already available (like in core tests), the installer might throw an error as the config tries to access the database.
We can simply skip that check in that case, as no system setting can be available.

This might actually only be an issue occurring in tests, at least I wasn't able to reproduce that locally.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
