### PR TITLE
Ignore errors when trying to set csp policy

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -11,11 +11,15 @@ return array(
             return $previous;
         }
 
-        $settings = new Piwik\Plugins\AnonymousPiwikUsageMeasurement\SystemSettings();
-        $customSiteUrl = $settings->getSetting('customSiteUrl')->getValue();
-        $host = parse_url($customSiteUrl, PHP_URL_HOST);
-        if (!empty($customSiteUrl) && !empty($host)) {
-            $previous->addPolicy('default-src', $host);
+        try {
+            $settings = new Piwik\Plugins\AnonymousPiwikUsageMeasurement\SystemSettings();
+            $customSiteUrl = $settings->getSetting('customSiteUrl')->getValue();
+            $host = parse_url($customSiteUrl, PHP_URL_HOST);
+            if (!empty($customSiteUrl) && !empty($host)) {
+                $previous->addPolicy('default-src', $host);
+            }
+        } catch (\Exception $e) {
+            // ignore possible errors as they might break Matomo
         }
         return $previous;
     })


### PR DESCRIPTION
This currently breaks the core UI tests, as they are trying to update from a very old database version (Piwik 1.0), where the table `plugin_setting` did not yet exist.

See https://app.travis-ci.com/github/matomo-org/matomo/jobs/545918261#L991   and   https://builds-artifacts.matomo.org/matomo-org/matomo/m-3513-stick-table-top/50575/processed/should_start_the_updater_when_an_old_version_of_Piwik_is_detected_in_the_DB_failure.png
for failure details
