### PR TITLE
Remove deprecation in javascript tests

### DIFF
--- a/javascripts/tracking.spec.js
+++ b/javascripts/tracking.spec.js
@@ -16,10 +16,6 @@
         initTrackers(false);
     }
 
-    // avoid angular emit as that causes problems in tests
-    // @todo remove with Matomo 5
-    piwik.postEvent = piwik.postEventNoEmit;
-
     function initTrackers(anonymize) {
         "use strict";
 


### PR DESCRIPTION
### Description:

The method `piwik.postEventNoEmit` does no longer exist since matomo-org/matomo#19496
### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
