### PR TITLE
Fix PHPUnit deprecation warnings in integration tests

### DIFF
--- a/tests/Integration/SystemSettingsTest.php
+++ b/tests/Integration/SystemSettingsTest.php
@@ -59,14 +59,14 @@ class SystemSettingsTest extends IntegrationTestCase
     public function test_ownPiwikSiteId_shouldThrowAnException_IfValueIsNotNumeric()
     {
         $this->expectException(\Exception::class);
-        $this->expectDeprecationMessage("Site Id 'MyTest0' should be a number");
+        $this->expectExceptionMessage("Site Id 'MyTest0' should be a number");
         $this->settings->ownPiwikSiteId->setValue('MyTest0');
     }
 
     public function test_ownPiwikSiteId_shouldThrowAnException_IfSiteIdDoesNotExist()
     {
         $this->expectException(\Exception::class);
-        $this->expectDeprecationMessage("The specified idSite '5' does not exist");
+        $this->expectExceptionMessage("The specified idSite '5' does not exist");
         $this->settings->ownPiwikSiteId->setValue('5');
     }
 
@@ -99,7 +99,7 @@ class SystemSettingsTest extends IntegrationTestCase
     public function test_customPiwikSiteUrl_shouldThrowAnException_WhenNotAValidUrlIsSet()
     {
         $this->expectException(\Exception::class);
-        $this->expectDeprecationMessage("URL 'http:/Valtes.com/idUrl' seems to be not a valid URL");
+        $this->expectExceptionMessage("URL 'http:/Valtes.com/idUrl' seems to be not a valid URL");
         $this->settings->customPiwikSiteUrl->setValue('http:/Valtes.com/idUrl');
     }
 
@@ -132,7 +132,7 @@ class SystemSettingsTest extends IntegrationTestCase
     public function test_customPiwikSiteId_shouldThrowAnException_IfValueIsNotNumeric()
     {
         $this->expectException(\Exception::class);
-        $this->expectDeprecationMessage("Site Id 'MyTest0' should be a number");
+        $this->expectExceptionMessage("Site Id 'MyTest0' should be a number");
         $this->settings->customPiwikSiteId->setValue('MyTest0');
     }
 }


### PR DESCRIPTION
## Description

This PR removes PHPUnit deprecation warnings in affected integration tests to improve PHPUnit 10 compatibility.

## Checklist
- [✔] Tested locally or on demo2/demo3?
- [NA] New test case added/updated?
- [NA] Are all newly added texts included via translation?
- [NA] Are text sanitized properly? (Eg use of v-text v/s v-html for vue)
- [NA] Version bumped?
- [NA] I have understood, reviewed, and tested all AI outputs before use
- [NA] All AI instructions respect security, IP, and privacy rules
