### PR TITLE
Run plugin tests against MySQL 8.0 and MariaDB 10.6

### DIFF
--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -39,6 +39,9 @@ jobs:
       matrix:
         php: [ '8.1', '8.5' ]
         target: ['minimum_required_matomo', 'maximum_supported_matomo']
+        database:
+          - { engine: 'Mysql', version: '8.0' }
+          - { engine: 'Mariadb', version: '10.6' }
     steps:
       - uses: actions/checkout@v3
         with:
@@ -52,6 +55,8 @@ jobs:
           plugin-name: 'AnonymousPiwikUsageMeasurement'
           php-version: ${{ matrix.php }}
           test-type: 'PluginTests'
+          mysql-engine: ${{ matrix.database.engine }}
+          mysql-version: ${{ matrix.database.version }}
           matomo-test-branch: ${{ matrix.target }}
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
           upload-artifacts: ${{ matrix.php == '8.1' && matrix.target == 'maximum_supported_matomo' }}
@@ -88,6 +93,8 @@ jobs:
           plugin-name: 'AnonymousPiwikUsageMeasurement'
           matomo-test-branch: 'maximum_supported_matomo'
           test-type: 'UI'
+          mysql-engine: 'Mysql'
+          mysql-version: '8.0'
           php-version: '8.1'
           node-version: '16'
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -59,7 +59,7 @@ jobs:
           mysql-version: ${{ matrix.database.version }}
           matomo-test-branch: ${{ matrix.target }}
           artifacts-pass: ${{ secrets.ARTIFACTS_PASS }}
-          upload-artifacts: ${{ matrix.php == '8.1' && matrix.target == 'maximum_supported_matomo' }}
+          upload-artifacts: ${{ matrix.php == '8.1' && matrix.target == 'maximum_supported_matomo' && matrix.database.engine == 'Mysql' }}
   Client:
     runs-on: ubuntu-24.04
     timeout-minutes: 15

--- a/.github/workflows/matomo-tests.yml
+++ b/.github/workflows/matomo-tests.yml
@@ -78,7 +78,7 @@ jobs:
           plugin-name: 'AnonymousPiwikUsageMeasurement'
           matomo-test-branch: ${{ matrix.target }}
           test-type: 'Client'
-          node-version: '16'
+          node-version: '24'
           mysql-service: false
   UI:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Updates the plugin test workflow to run against the new minimum supported database versions. It previously inherited the shared `github-action-tests` MySQL 5.7 default, which is below Matomo's new minimum (MySQL 8.0 / MariaDB 10.6).

**Core PR:** https://github.com/matomo-org/matomo/pull/24858

- **PluginTests** now runs a database matrix: **MySQL 8.0** and **MariaDB 10.6**.
- **UI** runs on **MySQL 8.0**.
- **Client** tests run on **Node 24** (Node 16 no longer supports the JS test runner — `crypto.getRandomValues` is unavailable — matching the Node version core uses).

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
