### PR TITLE
Stop using the removed API.getSettings method (Matomo 6)

### DIFF
--- a/tests/Fixtures/SendSystemReportTaskFixture.php
+++ b/tests/Fixtures/SendSystemReportTaskFixture.php
@@ -61,7 +61,6 @@ class SendSystemReportTaskFixture extends Fixture
     private function executeSomeApiMethods()
     {
         Request::processRequest('API.getPiwikVersion');
-        Request::processRequest('API.getSettings');
         Request::processRequest('UsersManager.getUsers');
         Request::processRequest('API.getPiwikVersion');
         Request::processRequest('VisitsSummary.get', array('idSite' => 1, 'period' => 'year', 'date' => 'today'));

--- a/tests/Integration/AnonymousPiwikUsageMeasurementTest.php
+++ b/tests/Integration/AnonymousPiwikUsageMeasurementTest.php
@@ -28,7 +28,6 @@ class AnonymousPiwikUsageMeasurementTest extends IntegrationTestCase
     public function test_shouldTrackApiCall()
     {
         Request::processRequest('API.getPiwikVersion');
-        Request::processRequest('API.getSettings');
         Request::processRequest('UsersManager.getUsers');
         Request::processRequest('API.getPiwikVersion');
 
@@ -49,12 +48,6 @@ class AnonymousPiwikUsageMeasurementTest extends IntegrationTestCase
                 'name' => 'API',
                 'action' => 'API.getPiwikVersion',
                 'count' => '2',
-            ),
-            array (
-                'category' => 'API',
-                'name' => 'API',
-                'action' => 'API.getSettings',
-                'count' => '1',
             ),
             array (
                 'category' => 'API',

--- a/tests/System/expected/test___API.get_year.xml
+++ b/tests/System/expected/test___API.get_year.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <result>
 	<nb_visits>1</nb_visits>
-	<nb_actions>39</nb_actions>
-	<max_actions>39</max_actions>
+	<nb_actions>37</nb_actions>
+	<max_actions>37</max_actions>
 	<bounce_count>0</bounce_count>
 	<nb_visits_new>1</nb_visits_new>
-	<nb_actions_new>39</nb_actions_new>
-	<max_actions_new>39</max_actions_new>
+	<nb_actions_new>37</nb_actions_new>
+	<max_actions_new>37</max_actions_new>
 	<bounce_rate_new>0%</bounce_rate_new>
-	<nb_actions_per_visit_new>39</nb_actions_per_visit_new>
+	<nb_actions_per_visit_new>37</nb_actions_per_visit_new>
 	<nb_visits_returning>0</nb_visits_returning>
 	<nb_actions_returning>0</nb_actions_returning>
 	<max_actions_returning>0</max_actions_returning>
@@ -81,10 +81,10 @@
 	<nb_actions_per_visit_ai_agent>0</nb_actions_per_visit_ai_agent>
 	<avg_time_on_site_ai_agent>0</avg_time_on_site_ai_agent>
 	<nb_visits_human>1</nb_visits_human>
-	<nb_actions_human>39</nb_actions_human>
-	<max_actions_human>39</max_actions_human>
+	<nb_actions_human>37</nb_actions_human>
+	<max_actions_human>37</max_actions_human>
 	<bounce_rate_human>0%</bounce_rate_human>
-	<nb_actions_per_visit_human>39</nb_actions_per_visit_human>
+	<nb_actions_per_visit_human>37</nb_actions_per_visit_human>
 	<avg_time_on_site_human>1</avg_time_on_site_human>
 	<Referrers_visitorsFromDirectEntry_percent>100%</Referrers_visitorsFromDirectEntry_percent>
 	<Referrers_visitorsFromSearchEngines_percent>0%</Referrers_visitorsFromSearchEngines_percent>
@@ -93,7 +93,7 @@
 	<Referrers_visitorsFromSocialNetworks_percent>0%</Referrers_visitorsFromSocialNetworks_percent>
 	<Referrers_visitorsFromWebsites_percent>0%</Referrers_visitorsFromWebsites_percent>
 	<bounce_rate>0%</bounce_rate>
-	<nb_actions_per_visit>39</nb_actions_per_visit>
+	<nb_actions_per_visit>37</nb_actions_per_visit>
 	<avg_time_on_site>1</avg_time_on_site>
 	<BotTracking_AIChatbotsClickThroughRate>0</BotTracking_AIChatbotsClickThroughRate>
 </result>

--- a/tests/System/expected/test___Actions.getPageTitles_year.xml
+++ b/tests/System/expected/test___Actions.getPageTitles_year.xml
@@ -6,7 +6,7 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<entry_nb_visits>1</entry_nb_visits>
-		<entry_nb_actions>39</entry_nb_actions>
+		<entry_nb_actions>37</entry_nb_actions>
 		<entry_bounce_count>0</entry_bounce_count>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>

--- a/tests/System/expected/test___Actions.getPageUrls_year.xml
+++ b/tests/System/expected/test___Actions.getPageUrls_year.xml
@@ -6,7 +6,7 @@
 		<nb_hits>1</nb_hits>
 		<sum_time_spent>0</sum_time_spent>
 		<entry_nb_visits>1</entry_nb_visits>
-		<entry_nb_actions>39</entry_nb_actions>
+		<entry_nb_actions>37</entry_nb_actions>
 		<entry_bounce_count>0</entry_bounce_count>
 		<exit_nb_visits>1</exit_nb_visits>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>

--- a/tests/System/expected/test___CustomVariables.getCustomVariables_year.xml
+++ b/tests/System/expected/test___CustomVariables.getCustomVariables_year.xml
@@ -3,8 +3,8 @@
 	<row>
 		<label>Matomo Version</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -20,8 +20,8 @@
 			<row>
 				<label>2.14.3</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>39</nb_actions>
-				<max_actions>39</max_actions>
+				<nb_actions>37</nb_actions>
+				<max_actions>37</max_actions>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -32,8 +32,8 @@
 	<row>
 		<label>Num Segments</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -49,8 +49,8 @@
 			<row>
 				<label>0</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>39</nb_actions>
-				<max_actions>39</max_actions>
+				<nb_actions>37</nb_actions>
+				<max_actions>37</max_actions>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -61,8 +61,8 @@
 	<row>
 		<label>Num Users</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -78,8 +78,8 @@
 			<row>
 				<label>1</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>39</nb_actions>
-				<max_actions>39</max_actions>
+				<nb_actions>37</nb_actions>
+				<max_actions>37</max_actions>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -90,8 +90,8 @@
 	<row>
 		<label>Num Websites</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -107,8 +107,8 @@
 			<row>
 				<label>1</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>39</nb_actions>
-				<max_actions>39</max_actions>
+				<nb_actions>37</nb_actions>
+				<max_actions>37</max_actions>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -119,8 +119,8 @@
 	<row>
 		<label>PHP Version</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
@@ -136,8 +136,8 @@
 			<row>
 				<label>5.5.27</label>
 				<nb_visits>1</nb_visits>
-				<nb_actions>39</nb_actions>
-				<max_actions>39</max_actions>
+				<nb_actions>37</nb_actions>
+				<max_actions>37</max_actions>
 				<bounce_count>0</bounce_count>
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>

--- a/tests/System/expected/test___Events.getAction_year.xml
+++ b/tests/System/expected/test___Events.getAction_year.xml
@@ -51,56 +51,6 @@
 		</subtable>
 	</row>
 	<row>
-		<label>API.getSettings (count)</label>
-		<nb_visits>1</nb_visits>
-		<nb_events>1</nb_events>
-		<nb_events_with_value>1</nb_events_with_value>
-		<sum_event_value>2</sum_event_value>
-		<min_event_value>2</min_event_value>
-		<max_event_value>2</max_event_value>
-		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_event_value>2</avg_event_value>
-		<segment>eventAction==API.getSettings+%28count%29</segment>
-		<subtable>
-			<row>
-				<label>API (count)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-		</subtable>
-	</row>
-	<row>
-		<label>API.getSettings (speed)</label>
-		<nb_visits>1</nb_visits>
-		<nb_events>1</nb_events>
-		<nb_events_with_value>1</nb_events_with_value>
-		<sum_event_value>2</sum_event_value>
-		<min_event_value>2</min_event_value>
-		<max_event_value>2</max_event_value>
-		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_event_value>2</avg_event_value>
-		<segment>eventAction==API.getSettings+%28speed%29</segment>
-		<subtable>
-			<row>
-				<label>API (speed)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-		</subtable>
-	</row>
-	<row>
 		<label>CoreAdminHome.invalidateArchivedReports (count)</label>
 		<nb_visits>1</nb_visits>
 		<nb_events>1</nb_events>

--- a/tests/System/expected/test___Events.getCategory_year.xml
+++ b/tests/System/expected/test___Events.getCategory_year.xml
@@ -2,9 +2,9 @@
 <result>
 	<row>
 		<label>API (count)</label>
-		<nb_visits>19</nb_visits>
-		<nb_events>19</nb_events>
-		<nb_events_with_value>19</nb_events_with_value>
+		<nb_visits>18</nb_visits>
+		<nb_events>18</nb_events>
+		<nb_events_with_value>18</nb_events_with_value>
 		<sum_event_value>2</sum_event_value>
 		<min_event_value>2</min_event_value>
 		<max_event_value>2</max_event_value>
@@ -14,17 +14,6 @@
 		<subtable>
 			<row>
 				<label>API.getPiwikVersion (count)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-			<row>
-				<label>API.getSettings (count)</label>
 				<nb_visits>1</nb_visits>
 				<nb_events>1</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>
@@ -225,9 +214,9 @@
 	</row>
 	<row>
 		<label>API (speed)</label>
-		<nb_visits>19</nb_visits>
-		<nb_events>19</nb_events>
-		<nb_events_with_value>19</nb_events_with_value>
+		<nb_visits>18</nb_visits>
+		<nb_events>18</nb_events>
+		<nb_events_with_value>18</nb_events_with_value>
 		<sum_event_value>2</sum_event_value>
 		<min_event_value>2</min_event_value>
 		<max_event_value>2</max_event_value>
@@ -237,17 +226,6 @@
 		<subtable>
 			<row>
 				<label>API.getPiwikVersion (speed)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-			<row>
-				<label>API.getSettings (speed)</label>
 				<nb_visits>1</nb_visits>
 				<nb_events>1</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>

--- a/tests/System/expected/test___Events.getName_year.xml
+++ b/tests/System/expected/test___Events.getName_year.xml
@@ -205,78 +205,6 @@
 		</subtable>
 	</row>
 	<row>
-		<label>API (count)</label>
-		<nb_visits>2</nb_visits>
-		<nb_events>2</nb_events>
-		<nb_events_with_value>2</nb_events_with_value>
-		<sum_event_value>2</sum_event_value>
-		<min_event_value>2</min_event_value>
-		<max_event_value>2</max_event_value>
-		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_event_value>2</avg_event_value>
-		<segment>eventName==API+%28count%29</segment>
-		<subtable>
-			<row>
-				<label>API.getPiwikVersion (count)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-			<row>
-				<label>API.getSettings (count)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-		</subtable>
-	</row>
-	<row>
-		<label>API (speed)</label>
-		<nb_visits>2</nb_visits>
-		<nb_events>2</nb_events>
-		<nb_events_with_value>2</nb_events_with_value>
-		<sum_event_value>2</sum_event_value>
-		<min_event_value>2</min_event_value>
-		<max_event_value>2</max_event_value>
-		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-		<avg_event_value>2</avg_event_value>
-		<segment>eventName==API+%28speed%29</segment>
-		<subtable>
-			<row>
-				<label>API.getPiwikVersion (speed)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-			<row>
-				<label>API.getSettings (speed)</label>
-				<nb_visits>1</nb_visits>
-				<nb_events>1</nb_events>
-				<nb_events_with_value>1</nb_events_with_value>
-				<sum_event_value>2</sum_event_value>
-				<min_event_value>2</min_event_value>
-				<max_event_value>2</max_event_value>
-				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
-				<avg_event_value>2</avg_event_value>
-			</row>
-		</subtable>
-	</row>
-	<row>
 		<label>SitesManager (count)</label>
 		<nb_visits>2</nb_visits>
 		<nb_events>2</nb_events>
@@ -337,6 +265,56 @@
 			</row>
 			<row>
 				<label>SitesManager.getSiteFromId (speed)</label>
+				<nb_visits>1</nb_visits>
+				<nb_events>1</nb_events>
+				<nb_events_with_value>1</nb_events_with_value>
+				<sum_event_value>2</sum_event_value>
+				<min_event_value>2</min_event_value>
+				<max_event_value>2</max_event_value>
+				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+				<avg_event_value>2</avg_event_value>
+			</row>
+		</subtable>
+	</row>
+	<row>
+		<label>API (count)</label>
+		<nb_visits>1</nb_visits>
+		<nb_events>1</nb_events>
+		<nb_events_with_value>1</nb_events_with_value>
+		<sum_event_value>2</sum_event_value>
+		<min_event_value>2</min_event_value>
+		<max_event_value>2</max_event_value>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_event_value>2</avg_event_value>
+		<segment>eventName==API+%28count%29</segment>
+		<subtable>
+			<row>
+				<label>API.getPiwikVersion (count)</label>
+				<nb_visits>1</nb_visits>
+				<nb_events>1</nb_events>
+				<nb_events_with_value>1</nb_events_with_value>
+				<sum_event_value>2</sum_event_value>
+				<min_event_value>2</min_event_value>
+				<max_event_value>2</max_event_value>
+				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+				<avg_event_value>2</avg_event_value>
+			</row>
+		</subtable>
+	</row>
+	<row>
+		<label>API (speed)</label>
+		<nb_visits>1</nb_visits>
+		<nb_events>1</nb_events>
+		<nb_events_with_value>1</nb_events_with_value>
+		<sum_event_value>2</sum_event_value>
+		<min_event_value>2</min_event_value>
+		<max_event_value>2</max_event_value>
+		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
+		<avg_event_value>2</avg_event_value>
+		<segment>eventName==API+%28speed%29</segment>
+		<subtable>
+			<row>
+				<label>API.getPiwikVersion (speed)</label>
 				<nb_visits>1</nb_visits>
 				<nb_events>1</nb_events>
 				<nb_events_with_value>1</nb_events_with_value>

--- a/tests/System/expected/test___Referrers.getReferrerType_year.xml
+++ b/tests/System/expected/test___Referrers.getReferrerType_year.xml
@@ -3,8 +3,8 @@
 	<row>
 		<label>Direct Entry</label>
 		<nb_visits>1</nb_visits>
-		<nb_actions>39</nb_actions>
-		<max_actions>39</max_actions>
+		<nb_actions>37</nb_actions>
+		<max_actions>37</max_actions>
 		<bounce_count>0</bounce_count>
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>


### PR DESCRIPTION
## Summary

Companion to matomo/matomo#24893 (Matomo 6 deprecation cleanup, round 2).

The core `API.getSettings` API method is removed in Matomo 6. This plugin used it only as a sample API call to exercise the profiler, so:

* Drop `Request::processRequest('API.getSettings')` from the profiler integration test (`AnonymousPiwikUsageMeasurementTest`) and the system-report fixture (`SendSystemReportTaskFixture`), and remove its entry from the expected profile array.
* Regenerate the affected system-test expected files: tracked API-call actions drop from 39 to 37, and the `API.getSettings` event rows are removed from the `Events.get*` reports (with the `Events.getName` ordering re-sorting by event count accordingly).

Verified locally with `tests:run TasksTest --group=AnonymousPiwikUsageMeasurement` (48/48 passing).

Based on `prepare6x`. The core PR advances the submodule pointer to this branch.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules
