### PR TITLE
Add percent-of-total metric columns to system test expected files

### DIFF
--- a/tests/System/expected/test___Actions.getPageTitles_year.xml
+++ b/tests/System/expected/test___Actions.getPageTitles_year.xml
@@ -13,6 +13,12 @@
 		<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 		<avg_page_load_time>0</avg_page_load_time>
+		<nb_visits_percent_of_total>100%</nb_visits_percent_of_total>
+		<nb_hits_percent_of_total>100%</nb_hits_percent_of_total>
+		<entry_bounce_count_percent_of_total>0%</entry_bounce_count_percent_of_total>
+		<entry_nb_visits_percent_of_total>100%</entry_nb_visits_percent_of_total>
+		<entry_nb_actions_percent_of_total>100%</entry_nb_actions_percent_of_total>
+		<exit_nb_visits_percent_of_total>100%</exit_nb_visits_percent_of_total>
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>

--- a/tests/System/expected/test___Actions.getPageUrls_year.xml
+++ b/tests/System/expected/test___Actions.getPageUrls_year.xml
@@ -13,6 +13,12 @@
 		<sum_daily_entry_nb_uniq_visitors>1</sum_daily_entry_nb_uniq_visitors>
 		<sum_daily_exit_nb_uniq_visitors>1</sum_daily_exit_nb_uniq_visitors>
 		<avg_page_load_time>0</avg_page_load_time>
+		<nb_visits_percent_of_total>100%</nb_visits_percent_of_total>
+		<nb_hits_percent_of_total>100%</nb_hits_percent_of_total>
+		<entry_bounce_count_percent_of_total>0%</entry_bounce_count_percent_of_total>
+		<entry_nb_visits_percent_of_total>100%</entry_nb_visits_percent_of_total>
+		<entry_nb_actions_percent_of_total>100%</entry_nb_actions_percent_of_total>
+		<exit_nb_visits_percent_of_total>100%</exit_nb_visits_percent_of_total>
 		<avg_time_on_page>0</avg_time_on_page>
 		<bounce_rate>0%</bounce_rate>
 		<exit_rate>100%</exit_rate>

--- a/tests/System/expected/test___CustomVariables.getCustomVariables_year.xml
+++ b/tests/System/expected/test___CustomVariables.getCustomVariables_year.xml
@@ -9,6 +9,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -26,6 +30,10 @@
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -38,6 +46,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -55,6 +67,10 @@
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -67,6 +83,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -84,6 +104,10 @@
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -96,6 +120,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -113,6 +141,10 @@
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -125,6 +157,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<slots>
 			<row>
 				<scope>visit</scope>
@@ -142,6 +178,10 @@
 				<nb_visits_converted>0</nb_visits_converted>
 				<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 				<sum_daily_nb_users>0</sum_daily_nb_users>
+				<nb_visits_percent_of_total>20%</nb_visits_percent_of_total>
+				<nb_actions_percent_of_total>20%</nb_actions_percent_of_total>
+				<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+				<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test___Events.getAction_year.xml
+++ b/tests/System/expected/test___Events.getAction_year.xml
@@ -10,6 +10,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==API.getPiwikVersion+%28count%29</segment>
 		<subtable>
 			<row>
@@ -22,6 +23,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -35,6 +37,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==API.getPiwikVersion+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -47,6 +50,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -60,6 +64,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==CoreAdminHome.invalidateArchivedReports+%28count%29</segment>
 		<subtable>
 			<row>
@@ -72,6 +77,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -85,6 +91,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==CoreAdminHome.invalidateArchivedReports+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -97,6 +104,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -110,6 +118,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==CustomDimensions.getConfiguredCustomDimensions+%28count%29</segment>
 		<subtable>
 			<row>
@@ -122,6 +131,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -135,6 +145,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==CustomDimensions.getConfiguredCustomDimensions+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -147,6 +158,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -160,6 +172,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==Dashboard.getDashboards+%28count%29</segment>
 		<subtable>
 			<row>
@@ -172,6 +185,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -185,6 +199,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==Dashboard.getDashboards+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -197,6 +212,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -210,6 +226,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==Goals.getGoals+%28count%29</segment>
 		<subtable>
 			<row>
@@ -222,6 +239,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -235,6 +253,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==Goals.getGoals+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -247,6 +266,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -260,6 +280,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==LanguagesManager.uses12HourClockForUser+%28count%29</segment>
 		<subtable>
 			<row>
@@ -272,6 +293,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -285,6 +307,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==LanguagesManager.uses12HourClockForUser+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -297,6 +320,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -310,6 +334,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==SitesManager.getAllSites+%28count%29</segment>
 		<subtable>
 			<row>
@@ -322,6 +347,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -335,6 +361,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==SitesManager.getAllSites+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -347,6 +374,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -360,6 +388,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==SitesManager.getSiteFromId+%28count%29</segment>
 		<subtable>
 			<row>
@@ -372,6 +401,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -385,6 +415,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==SitesManager.getSiteFromId+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -397,6 +428,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -410,6 +442,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainer+%28count%29</segment>
 		<subtable>
 			<row>
@@ -422,6 +455,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -435,6 +469,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainer+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -447,6 +482,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -460,6 +496,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerTag+%28count%29</segment>
 		<subtable>
 			<row>
@@ -472,6 +509,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -485,6 +523,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerTag+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -497,6 +536,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -510,6 +550,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerTrigger+%28count%29</segment>
 		<subtable>
 			<row>
@@ -522,6 +563,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -535,6 +577,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerTrigger+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -547,6 +590,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -560,6 +604,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerVariable+%28count%29</segment>
 		<subtable>
 			<row>
@@ -572,6 +617,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -585,6 +631,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.addContainerVariable+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -597,6 +644,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -610,6 +658,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.createContainerVersion+%28count%29</segment>
 		<subtable>
 			<row>
@@ -622,6 +671,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -635,6 +685,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.createContainerVersion+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -647,6 +698,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -660,6 +712,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.createDefaultContainerForSite+%28count%29</segment>
 		<subtable>
 			<row>
@@ -672,6 +725,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -685,6 +739,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.createDefaultContainerForSite+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -697,6 +752,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -710,6 +766,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.getAvailableEnvironments+%28count%29</segment>
 		<subtable>
 			<row>
@@ -722,6 +779,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -735,6 +793,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.getAvailableEnvironments+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -747,6 +806,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -760,6 +820,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.publishContainerVersion+%28count%29</segment>
 		<subtable>
 			<row>
@@ -772,6 +833,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -785,6 +847,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==TagManager.publishContainerVersion+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -797,6 +860,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -810,6 +874,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==UsersManager.getUsers+%28count%29</segment>
 		<subtable>
 			<row>
@@ -822,6 +887,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -835,6 +901,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==UsersManager.getUsers+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -847,6 +914,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -860,6 +928,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==VisitsSummary.get+%28count%29</segment>
 		<subtable>
 			<row>
@@ -872,6 +941,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -885,6 +955,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventAction==VisitsSummary.get+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -897,6 +968,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test___Events.getCategory_year.xml
+++ b/tests/System/expected/test___Events.getCategory_year.xml
@@ -10,6 +10,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>50%</nb_visits_percent_of_total>
 		<segment>eventCategory==API+%28count%29</segment>
 		<subtable>
 			<row>
@@ -22,6 +23,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>CoreAdminHome.invalidateArchivedReports (count)</label>
@@ -33,6 +35,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>CustomDimensions.getConfiguredCustomDimensions (count)</label>
@@ -44,6 +47,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>Dashboard.getDashboards (count)</label>
@@ -55,6 +59,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>Goals.getGoals (count)</label>
@@ -66,6 +71,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>LanguagesManager.uses12HourClockForUser (count)</label>
@@ -77,6 +83,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getAllSites (count)</label>
@@ -88,6 +95,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getSiteFromId (count)</label>
@@ -99,6 +107,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainer (count)</label>
@@ -110,6 +119,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTag (count)</label>
@@ -121,6 +131,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTrigger (count)</label>
@@ -132,6 +143,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerVariable (count)</label>
@@ -143,6 +155,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createContainerVersion (count)</label>
@@ -154,6 +167,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createDefaultContainerForSite (count)</label>
@@ -165,6 +179,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.getAvailableEnvironments (count)</label>
@@ -176,6 +191,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.publishContainerVersion (count)</label>
@@ -187,6 +203,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>UsersManager.getUsers (count)</label>
@@ -198,6 +215,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>VisitsSummary.get (count)</label>
@@ -209,6 +227,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -222,6 +241,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>50%</nb_visits_percent_of_total>
 		<segment>eventCategory==API+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -234,6 +254,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>CoreAdminHome.invalidateArchivedReports (speed)</label>
@@ -245,6 +266,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>CustomDimensions.getConfiguredCustomDimensions (speed)</label>
@@ -256,6 +278,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>Dashboard.getDashboards (speed)</label>
@@ -267,6 +290,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>Goals.getGoals (speed)</label>
@@ -278,6 +302,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>LanguagesManager.uses12HourClockForUser (speed)</label>
@@ -289,6 +314,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getAllSites (speed)</label>
@@ -300,6 +326,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getSiteFromId (speed)</label>
@@ -311,6 +338,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainer (speed)</label>
@@ -322,6 +350,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTag (speed)</label>
@@ -333,6 +362,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTrigger (speed)</label>
@@ -344,6 +374,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerVariable (speed)</label>
@@ -355,6 +386,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createContainerVersion (speed)</label>
@@ -366,6 +398,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createDefaultContainerForSite (speed)</label>
@@ -377,6 +410,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.getAvailableEnvironments (speed)</label>
@@ -388,6 +422,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.publishContainerVersion (speed)</label>
@@ -399,6 +434,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>UsersManager.getUsers (speed)</label>
@@ -410,6 +446,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>VisitsSummary.get (speed)</label>
@@ -421,6 +458,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test___Events.getName_year.xml
+++ b/tests/System/expected/test___Events.getName_year.xml
@@ -10,6 +10,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>22.2%</nb_visits_percent_of_total>
 		<segment>eventName==TagManager+%28count%29</segment>
 		<subtable>
 			<row>
@@ -22,6 +23,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTag (count)</label>
@@ -33,6 +35,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTrigger (count)</label>
@@ -44,6 +47,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerVariable (count)</label>
@@ -55,6 +59,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createContainerVersion (count)</label>
@@ -66,6 +71,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createDefaultContainerForSite (count)</label>
@@ -77,6 +83,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.getAvailableEnvironments (count)</label>
@@ -88,6 +95,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.publishContainerVersion (count)</label>
@@ -99,6 +107,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -112,6 +121,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>22.2%</nb_visits_percent_of_total>
 		<segment>eventName==TagManager+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -124,6 +134,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTag (speed)</label>
@@ -135,6 +146,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerTrigger (speed)</label>
@@ -146,6 +158,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.addContainerVariable (speed)</label>
@@ -157,6 +170,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createContainerVersion (speed)</label>
@@ -168,6 +182,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.createDefaultContainerForSite (speed)</label>
@@ -179,6 +194,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.getAvailableEnvironments (speed)</label>
@@ -190,6 +206,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>TagManager.publishContainerVersion (speed)</label>
@@ -201,6 +218,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -214,6 +232,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
 		<segment>eventName==SitesManager+%28count%29</segment>
 		<subtable>
 			<row>
@@ -226,6 +245,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getSiteFromId (count)</label>
@@ -237,6 +257,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -250,6 +271,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>5.6%</nb_visits_percent_of_total>
 		<segment>eventName==SitesManager+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -262,6 +284,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 			<row>
 				<label>SitesManager.getSiteFromId (speed)</label>
@@ -273,6 +296,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -286,6 +310,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==API+%28count%29</segment>
 		<subtable>
 			<row>
@@ -298,6 +323,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -311,6 +337,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==API+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -323,6 +350,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -336,6 +364,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==CoreAdminHome+%28count%29</segment>
 		<subtable>
 			<row>
@@ -348,6 +377,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -361,6 +391,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==CoreAdminHome+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -373,6 +404,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -386,6 +418,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==CustomDimensions+%28count%29</segment>
 		<subtable>
 			<row>
@@ -398,6 +431,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -411,6 +445,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==CustomDimensions+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -423,6 +458,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -436,6 +472,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==Dashboard+%28count%29</segment>
 		<subtable>
 			<row>
@@ -448,6 +485,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -461,6 +499,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==Dashboard+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -473,6 +512,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -486,6 +526,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==Goals+%28count%29</segment>
 		<subtable>
 			<row>
@@ -498,6 +539,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -511,6 +553,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==Goals+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -523,6 +566,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -536,6 +580,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==LanguagesManager+%28count%29</segment>
 		<subtable>
 			<row>
@@ -548,6 +593,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -561,6 +607,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==LanguagesManager+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -573,6 +620,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -586,6 +634,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==UsersManager+%28count%29</segment>
 		<subtable>
 			<row>
@@ -598,6 +647,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -611,6 +661,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==UsersManager+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -623,6 +674,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -636,6 +688,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==VisitsSummary+%28count%29</segment>
 		<subtable>
 			<row>
@@ -648,6 +701,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>
@@ -661,6 +715,7 @@
 		<max_event_value>2</max_event_value>
 		<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 		<avg_event_value>2</avg_event_value>
+		<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 		<segment>eventName==VisitsSummary+%28speed%29</segment>
 		<subtable>
 			<row>
@@ -673,6 +728,7 @@
 				<max_event_value>2</max_event_value>
 				<sum_daily_nb_uniq_visitors>2</sum_daily_nb_uniq_visitors>
 				<avg_event_value>2</avg_event_value>
+				<nb_visits_percent_of_total>2.8%</nb_visits_percent_of_total>
 			</row>
 		</subtable>
 	</row>

--- a/tests/System/expected/test___Referrers.getReferrerType_year.xml
+++ b/tests/System/expected/test___Referrers.getReferrerType_year.xml
@@ -9,6 +9,10 @@
 		<nb_visits_converted>0</nb_visits_converted>
 		<sum_daily_nb_uniq_visitors>1</sum_daily_nb_uniq_visitors>
 		<sum_daily_nb_users>0</sum_daily_nb_users>
+		<nb_visits_percent_of_total>100%</nb_visits_percent_of_total>
+		<nb_actions_percent_of_total>100%</nb_actions_percent_of_total>
+		<nb_visits_converted_percent_of_total>0%</nb_visits_converted_percent_of_total>
+		<bounce_count_percent_of_total>0%</bounce_count_percent_of_total>
 		<segment>referrerType==direct</segment>
 		<referrer_type>1</referrer_type>
 	</row>


### PR DESCRIPTION
Companion to matomo-org/matomo#24983 (Matomo 6, DEV-14950), which adds always-on `{metric}_percent_of_total` columns to report rows in API responses.

These expected files only pass against a Matomo 6 core containing that change, so this PR stays draft until the core PR is merged. CI here may be red against older core branches.

Note the branch is based on the commit currently pinned by the matomo 6.x-dev submodule, not the tip of 5.x-dev, so the gitlink in the core PR advances cleanly.

### Checklist
- [✔] I have understood, reviewed, and tested all AI outputs before use
- [✔] All AI instructions respect security, IP, and privacy rules